### PR TITLE
format-report: handle enriched device dicts in full-report protocol section

### DIFF
--- a/action/format-report.py
+++ b/action/format-report.py
@@ -1147,7 +1147,9 @@ def format_full_report(schematic_path, pcb_path, spice_path, emc_path, derating_
                 issues = finding.get("issues", []) or []
                 checks = finding.get("checks", {})
                 devices = finding.get("devices", [])
-                dev_str = f" ({', '.join(devices)})" if devices else ""
+                dev_names = [d.get('reference', d.get('ref', str(d))) if isinstance(d, dict) else str(d)
+                             for d in devices]
+                dev_str = f" ({', '.join(dev_names)})" if dev_names else ""
                 a(f"**{proto}**{dev_str}")
                 for check_name, check_data in checks.items():
                     if isinstance(check_data, dict) and "status" in check_data:


### PR DESCRIPTION
The full report's Protocol Compliance section crashes when findings carry enriched device dicts:

```
File "action/format-report.py", line 1150, in format_full_report
    dev_str = f" ({', '.join(devices)})" if devices else ""
TypeError: sequence item 0: expected str instance, dict found
```

`analyze_schematic.py` emits protocol-finding `devices` as enriched `{ref, value, lib_id}` dicts (`_enrich_device_ref`), e.g. for I2C bus findings. The short-report path already coerces these at `format-report.py:524`; this PR applies the same idiom to the full-report path.

Hit in CI on a project with multiple named I2C buses (the GitHub action analyzes fine, then dies in Report Generation). Verified locally: formatter completes and renders device refs in the protocol section.