### PR TITLE
fix(schematic-analyzer): correct mirrored component coordinate mapping

### DIFF
--- a/skills/kicad/scripts/analyze_schematic.py
+++ b/skills/kicad/scripts/analyze_schematic.py
@@ -358,9 +358,9 @@ def compute_pin_positions(component: dict, lib_symbols: dict) -> list[dict]:
         else:
             # KiCad 6+: decomposed angle + mirror
             if mirror_x:
-                py = -py
-            if mirror_y:
                 px = -px
+            if mirror_y:
+                py = -py
             rpx, rpy = apply_rotation(px, py, angle)
 
         # Absolute position: Y-axis inversion (symbol coords are math-up, schematic is screen-down)


### PR DESCRIPTION
The decomposed transformation logic for KiCad 6+ symbols in `analyze_schematic.py` incorrectly mapped `mirror_x` to a vertical flip (flipping Y) and `mirror_y` to a horizontal flip (flipping X). In KiCad, horizontal mirroring swaps the left and right pin positions along the X-axis (mirror x).

This mapping swap caused the analyzer to fail to mirror horizontal pin coordinates for components placed with `(mirror x)` in the schematic. As a result, pin numbers were incorrectly calculated after rotation.

## Testing

I ran this against the entire test corpus with `python3 run/run_schematic.py`. Three of the files timeout out, all others passed.

I also tested this with `python3 regression/run_checks.py`, which passed:

```
$ python3 regression/run_checks.py
Parser verification: 25063 files checked across 3984 repos
Total mismatches: 0 (0 repos affected)
Report: reports/parser_verification/latest.md
```

I tried running `python3 regression/run_checks.py --type schematic`, but there seem to be many pre-existing failures.