### PR TITLE
docs: add OSHWA guidance to KiCad skill

### DIFF
--- a/skills/kicad/SKILL.md
+++ b/skills/kicad/SKILL.md
@@ -13,8 +13,8 @@ description: >-
   tracing, power budget, DFM, or wants to understand, debug, compare, or
   review any hardware design. Also for "check my board", "review before fab",
   "what's wrong with my schematic", "is this ready to order", "check my power
-  supply", "verify this circuit", OSHWA/OSHWay certification, or open-source
-  hardware releases.
+  supply", "verify this circuit", OSHWA certification readiness, or any
+  electronics/PCB design question.
 ---
 
 # KiCad Project Analysis Skill
@@ -38,22 +38,6 @@ description: >-
 **Before analysis:** When the user asks to analyze or review a KiCad project, check whether a `datasheets/` directory exists in the project. If not, and DigiKey API keys are available (`DIGIKEY_CLIENT_ID`), offer to sync datasheets first: "I can download datasheets for your components before analysis — this enables pin-level verification and decoupling validation against manufacturer specs. Want me to sync them?" If the user declines or no API keys are set, proceed without datasheets — the analysis works without them but datasheet verification findings won't be available.
 
 **If you see a `DS-001` finding in the analyzer output** (severity `high`, detector `audit_datasheet_coverage`), the review cannot make any verified claim. Stop and either (a) run the datasheet sync via `digikey` / `mouser` / `lcsc` / `element14` (whichever has credentials/stock), (b) populate MPNs on the BOM parts, or (c) state explicitly in the report that every pin-level, electrical, and regulator finding is *consistency only* — do not use the words "verified", "confirmed", or "per datasheet" anywhere. `DS-002` (datasheets missing but MPNs set) and `DS-003` (partial MPN coverage) are softer variants with the same implication for the parts they cite.
-
-## OSHWA Certification
-
-When the user asks for OSHWA certification, an "OSHWay" review, or an
-open-source hardware release, read
-`references/oshwa-certification.md`. Treat this as a release-documentation and
-licensing audit, not as an electrical certification inferred from schematic
-topology.
-
-Inspect the editable KiCad sources, BOM, firmware, documentation, public
-release URLs, versioning, and license notices. Report missing or ambiguous
-items as certification gaps. Do not submit an OSHWA application, accept its
-license agreement, publish previously private design files, or add the
-certification mark unless the user explicitly authorizes that action. Add the
-mark only after OSHWA issues the project UID, then rerun the normal
-schematic/layout verification because placing the mark changes design files.
 
 ## Design Review Contract
 
@@ -756,7 +740,7 @@ Detailed methodology and format documentation lives in reference files. Read the
 | `manual-gerber-parsing.md` | 621 | Fallback when Gerber script fails |
 | `report-generation.md` | 614 | Report template (critical findings at top), analyzer output field reference (schematic/PCB/gerber), severity definitions, writing principles, domain-specific focus areas, known analyzer limitations |
 | `standards-compliance.md` | 638 | IPC/IEC standards tables: conductor spacing (IPC-2221A Table 6-1), current capacity (IPC-2221A/IPC-2152), annular rings, hole sizes, impedance, via protection (IPC-4761), creepage/clearance (ECMA-287/IEC 60664-1). Consider for all boards; auto-trigger for professional/industrial designs, high voltage, mains input, or safety isolation. |
-| `oshwa-certification.md` | — | OSHWA open-source hardware certification readiness: editable KiCad sources, public documentation, licensing, version registration, and certification-mark use |
+| `oshwa-certification.md` | — | OSHWA open-source hardware certification readiness: editable KiCad sources, public documentation, licensing, version registration, certification-mark use. Read when the user asks about OSHWA certification or an open-source hardware release — a documentation/licensing audit with explicit approval gates, not an electrical check |
 | `design-intent.md` | — | Design intent resolution, target market / certification / power constraints that gate findings by context |
 | `diff-analysis.md` | — | How `diff_analysis.py` compares two analyzer runs and emits severity-ranked change reports |
 | `what-if.md` | — | How `what_if.py` patches component values, recalculates derived fields, and suggests fixes for feedback dividers / crystal load caps / cap derating |

--- a/skills/kicad/SKILL.md
+++ b/skills/kicad/SKILL.md
@@ -13,7 +13,8 @@ description: >-
   tracing, power budget, DFM, or wants to understand, debug, compare, or
   review any hardware design. Also for "check my board", "review before fab",
   "what's wrong with my schematic", "is this ready to order", "check my power
-  supply", "verify this circuit", or any electronics/PCB design question.
+  supply", "verify this circuit", OSHWA/OSHWay certification, or open-source
+  hardware releases.
 ---
 
 # KiCad Project Analysis Skill
@@ -37,6 +38,22 @@ description: >-
 **Before analysis:** When the user asks to analyze or review a KiCad project, check whether a `datasheets/` directory exists in the project. If not, and DigiKey API keys are available (`DIGIKEY_CLIENT_ID`), offer to sync datasheets first: "I can download datasheets for your components before analysis — this enables pin-level verification and decoupling validation against manufacturer specs. Want me to sync them?" If the user declines or no API keys are set, proceed without datasheets — the analysis works without them but datasheet verification findings won't be available.
 
 **If you see a `DS-001` finding in the analyzer output** (severity `high`, detector `audit_datasheet_coverage`), the review cannot make any verified claim. Stop and either (a) run the datasheet sync via `digikey` / `mouser` / `lcsc` / `element14` (whichever has credentials/stock), (b) populate MPNs on the BOM parts, or (c) state explicitly in the report that every pin-level, electrical, and regulator finding is *consistency only* — do not use the words "verified", "confirmed", or "per datasheet" anywhere. `DS-002` (datasheets missing but MPNs set) and `DS-003` (partial MPN coverage) are softer variants with the same implication for the parts they cite.
+
+## OSHWA Certification
+
+When the user asks for OSHWA certification, an "OSHWay" review, or an
+open-source hardware release, read
+`references/oshwa-certification.md`. Treat this as a release-documentation and
+licensing audit, not as an electrical certification inferred from schematic
+topology.
+
+Inspect the editable KiCad sources, BOM, firmware, documentation, public
+release URLs, versioning, and license notices. Report missing or ambiguous
+items as certification gaps. Do not submit an OSHWA application, accept its
+license agreement, publish previously private design files, or add the
+certification mark unless the user explicitly authorizes that action. Add the
+mark only after OSHWA issues the project UID, then rerun the normal
+schematic/layout verification because placing the mark changes design files.
 
 ## Design Review Contract
 
@@ -739,6 +756,7 @@ Detailed methodology and format documentation lives in reference files. Read the
 | `manual-gerber-parsing.md` | 621 | Fallback when Gerber script fails |
 | `report-generation.md` | 614 | Report template (critical findings at top), analyzer output field reference (schematic/PCB/gerber), severity definitions, writing principles, domain-specific focus areas, known analyzer limitations |
 | `standards-compliance.md` | 638 | IPC/IEC standards tables: conductor spacing (IPC-2221A Table 6-1), current capacity (IPC-2221A/IPC-2152), annular rings, hole sizes, impedance, via protection (IPC-4761), creepage/clearance (ECMA-287/IEC 60664-1). Consider for all boards; auto-trigger for professional/industrial designs, high voltage, mains input, or safety isolation. |
+| `oshwa-certification.md` | — | OSHWA open-source hardware certification readiness: editable KiCad sources, public documentation, licensing, version registration, and certification-mark use |
 | `design-intent.md` | — | Design intent resolution, target market / certification / power constraints that gate findings by context |
 | `diff-analysis.md` | — | How `diff_analysis.py` compares two analyzer runs and emits severity-ranked change reports |
 | `what-if.md` | — | How `what_if.py` patches component values, recalculates derived fields, and suggests fixes for feedback dividers / crystal load caps / cap derating |

--- a/skills/kicad/references/oshwa-certification.md
+++ b/skills/kicad/references/oshwa-certification.md
@@ -1,0 +1,89 @@
+# OSHWA Certification Readiness
+
+Use this reference when preparing or auditing a KiCad project for the Open
+Source Hardware Association (OSHWA) certification program. Users may spell or
+pronounce the name "OSHWay"; use the official name OSHWA in deliverables.
+
+Certification is a legal and publication workflow, not an electrical safety,
+EMC, radio, or manufacturing approval. Do not describe a board as OSHWA
+certified until OSHWA has accepted the application and assigned a unique ID
+(UID).
+
+## Readiness Workflow
+
+1. Define the product and version being certified. Keep the released source,
+   documentation, and BOM tied to that exact version. Treat a materially new
+   version as a separate registration unless current OSHWA guidance says
+   otherwise.
+2. Identify everything controlled by the creator: hardware, required software
+   or firmware, documentation, and branding. Clearly distinguish proprietary
+   third-party parts and other excluded material.
+3. Publish the preferred editable source for modification. For KiCad projects,
+   include the applicable `.kicad_pro`, `.kicad_sch`, `.kicad_pcb`, custom
+   `.kicad_sym` libraries, `.pretty/` footprint libraries, and project-specific
+   design-rule files. Include mechanical source, FPGA/firmware source, and
+   build or programming instructions when needed to reproduce the product.
+   Gerbers, PDFs, and rendered images are useful release artifacts but do not
+   replace editable design source.
+4. Publish a BOM with references, quantities, values, footprints, and enough
+   manufacturer/part-number detail to reproduce the design. Ensure third-party
+   components have publicly accessible datasheets.
+5. Apply compatible licenses to each creator-controlled element. Use an
+   OSHWA-approved open hardware license for hardware, an OSI-approved license
+   for required software, and an open documentation license. Do not use
+   NonCommercial or NoDerivatives restrictions for certification material.
+   Record the selected license in the repository and, where practical, in the
+   KiCad title block or schematic/PCB text.
+6. Test every public project and documentation URL in a logged-out session.
+   Confirm that a user can find the source, BOM, license, version, and build
+   information without requesting access.
+7. Run the normal KiCad review and fabrication gates independently. OSHWA
+   readiness does not replace ERC, DRC, DFM, EMC, safety, radio, or regulatory
+   checks.
+8. Present a readiness report with `ready`, `gap`, or `not applicable` for each
+   checklist item. Separate factual repository findings from licensing
+   judgments, and recommend qualified legal advice when ownership or license
+   compatibility is unclear.
+9. Submit the certification application only with explicit user authorization.
+   Applying includes accepting OSHWA's certification license agreement and
+   making claims about public artifacts, so never do it as an implicit review
+   step.
+10. After OSHWA issues the UID, obtain the official mark artwork, add the UID
+    where appropriate, and follow the current mark-usage guide. Never invent a
+    UID or place the certification mark before approval. Re-run ERC/DRC and
+    regenerate release outputs after changing the schematic, PCB, enclosure,
+    or documentation.
+
+## Readiness Report
+
+Report at least:
+
+- project name and exact version
+- public project and source URLs
+- editable source inventory and missing files
+- BOM completeness and datasheet accessibility
+- hardware, software, and documentation licenses
+- proprietary or excluded elements and how they are identified
+- reproduction/build instructions
+- OSHWA application status and UID, if already issued
+- certification-mark status
+- unrelated engineering or regulatory checks performed and skipped
+- blocking gaps and the next action for each
+
+Do not provide legal conclusions. State what the files and current OSHWA
+requirements show, identify ambiguity, and request owner or counsel review for
+unclear copyright, patent, trademark, contributor, or third-party-license
+rights.
+
+## Official Sources
+
+Verify current requirements immediately before a readiness decision or
+application:
+
+- Requirements: <https://certification.oshwa.org/requirements.html>
+- Certification process: <https://certification.oshwa.org/process.html>
+- Hardware licensing: <https://certification.oshwa.org/process/hardware.html>
+- Software licensing: <https://certification.oshwa.org/process/software.html>
+- Documentation: <https://certification.oshwa.org/process/documentation.html>
+- Certification mark: <https://certification.oshwa.org/mark-usage.html>
+- License agreement: <https://certification.oshwa.org/license-agreement.html>

--- a/skills/kicad/references/oshwa-certification.md
+++ b/skills/kicad/references/oshwa-certification.md
@@ -1,8 +1,7 @@
 # OSHWA Certification Readiness
 
 Use this reference when preparing or auditing a KiCad project for the Open
-Source Hardware Association (OSHWA) certification program. Users may spell or
-pronounce the name "OSHWay"; use the official name OSHWA in deliverables.
+Source Hardware Association (OSHWA) certification program.
 
 Certification is a legal and publication workflow, not an electrical safety,
 EMC, radio, or manufacturing approval. Do not describe a board as OSHWA
@@ -28,10 +27,11 @@ certified until OSHWA has accepted the application and assigned a unique ID
 4. Publish a BOM with references, quantities, values, footprints, and enough
    manufacturer/part-number detail to reproduce the design. Ensure third-party
    components have publicly accessible datasheets.
-5. Apply compatible licenses to each creator-controlled element. Use an
-   OSHWA-approved open hardware license for hardware, an OSI-approved license
-   for required software, and an open documentation license. Do not use
-   NonCommercial or NoDerivatives restrictions for certification material.
+5. Apply compatible licenses to each creator-controlled element. Use a
+   recognized open hardware license for hardware (e.g. CERN-OHL, TAPR OHL,
+   Solderpad), an OSI-approved license for required software, and an open
+   documentation license. Do not use NonCommercial or NoDerivatives
+   restrictions for certification material.
    Record the selected license in the repository and, where practical, in the
    KiCad title block or schematic/PCB text.
 6. Test every public project and documentation URL in a logged-out session.


### PR DESCRIPTION
## What changed

- Trigger the KiCad skill for OSHWA and common “OSHWay” wording.
- Add an OSHWA certification-readiness workflow covering editable KiCad
  sources, BOM and datasheet availability, hardware/software/documentation
  licensing, public release URLs, versioning, application authorization, and
  certification-mark use.
- Link the new reference from the KiCad skill’s reference index.

## Why

OSHWA certification is a publication and licensing workflow, not an electrical
certification that can be inferred from PCB topology. The skill now
distinguishes those concerns and gives agents a bounded, source-backed
readiness checklist.

## Impact

Users can ask the KiCad skill to prepare or audit an open-source hardware
release while preserving explicit approval gates for publishing private files,
accepting the OSHWA agreement, submitting an application, and placing the
certification mark.

## Validation

- `quick_validate.py skills/kicad` — passed
- `git diff --check` — passed

Official requirements and mark-usage pages are linked directly from the new
reference.
