### PR TITLE
Support using kicad-happy as a Google Antigravity plugin

### DIFF
--- a/.agents/skills/datasheets
+++ b/.agents/skills/datasheets
@@ -1,0 +1,1 @@
+../../skills/datasheets

--- a/.agents/skills/kidoc
+++ b/.agents/skills/kidoc
@@ -1,1 +1,0 @@
-../../skills/kidoc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,12 +146,12 @@ description: One paragraph describing what this skill does and when to use it. I
 
 2. Add any scripts to `skills/<name>/scripts/`
 3. Add a symlink in `.agents/skills/`: `ln -s ../../skills/<name> .agents/skills/<name>`
-    *   **Gemini CLI:** Use `gemini skills link . --scope workspace` to link the whole repo.
+    *   **Antigravity CLI / Gemini:** Run `agy plugin install .` to install/update the local plugin.
     *   **opencode:** No per-skill registration needed — `.opencode/opencode.json` points the loader at the whole `skills/` tree, so new skills under `skills/<name>/SKILL.md` are auto-discovered.
-4. Update the manual install lists in `README.md` (Claude Code, Codex, Gemini, and opencode sections)
+4. Update the manual install lists in `README.md` (Claude Code, Codex, Antigravity/Gemini, and opencode sections)
 5. Validate:
     *   **Claude Code:** `claude plugin validate .`
-    *   **Gemini CLI:** Run `/skills reload` in an active session to verify discovery.
+    *   **Antigravity CLI:** Run `agy plugin validate .` to verify plugin structure and skills.
     *   **opencode:** Run `/skills list` in an active session to verify the new skill appears.
     *   **All skills:** `python3 .github/scripts/check_skill_metadata.py` (description ≤ 1024 chars; CI runs this on every PR).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 AI-powered design review for KiCad. Analyzes schematics, PCB layouts, and Gerbers. Catches real bugs before you order boards.
 
-Works with **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, **[OpenAI Codex](https://github.com/openai/codex)**, **[GitHub Copilot CLI](https://docs.github.com/en/copilot)**, **[Gemini CLI](https://github.com/google-gemini/gemini-cli)**, and **[opencode](https://github.com/sst/opencode)**, as a **GitHub Action** for automated PR reviews, or as standalone Python scripts you can run anywhere.
+Works with **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, **[OpenAI Codex](https://github.com/openai/codex)**, **[GitHub Copilot CLI](https://docs.github.com/en/copilot)**, **[Google Antigravity](https://antigravity.google)**, and **[opencode](https://github.com/sst/opencode)**, as a **GitHub Action** for automated PR reviews, or as standalone Python scripts you can run anywhere.
 
 These skills turn your AI coding agent into a full-fledged electronics design assistant that understands your KiCad projects at a deep level: parses schematics and PCB layouts into structured data, cross-references component values against datasheets, detects common design errors, and walks you through the full prototype-to-production workflow.
 

--- a/README.md
+++ b/README.md
@@ -117,24 +117,30 @@ Use Codex's built-in skill installer first:
 
 If you prefer a manual install, install the skills into `~/.codex/skills/`.
 
-**Google Gemini CLI:**
+**Google Antigravity CLI (`agy`) / Gemini:**
 
-`gemini skills install <url>` does not recurse into this monorepo's `skills/` directory. Clone and link all 11 at once:
+Install directly from GitHub as an Antigravity plugin:
+
+```bash
+agy plugin install https://github.com/aklofas/kicad-happy.git
+```
+
+Or from a local checkout:
 
 ```bash
 git clone https://github.com/aklofas/kicad-happy.git
-gemini skills link ./kicad-happy/skills
+agy plugin install kicad-happy
 ```
 
-Or install all 11 skills directly from the URL using `--path` (requires Gemini CLI ≥ Jan 13 2026):
+Toggle when needed:
 
 ```bash
-for skill in kicad spice emc datasheets bom digikey mouser lcsc element14 jlcpcb pcbway; do
-  gemini skills install https://github.com/aklofas/kicad-happy.git --path skills/$skill
-done
+agy plugin disable kicad-happy   # Disable when not doing electronics review
+agy plugin enable kicad-happy    # Enable when working on KiCad projects
 ```
 
-See [install-guidance.md](install-guidance.md#google-gemini-cli) for workspace-scope installs and upgrade notes.
+See [install-guidance.md](install-guidance.md#google-antigravity-cli-agy--gemini) for workspace-scope installs, slash commands, and upgrade notes.
+
 
 **opencode:**
 

--- a/install-guidance.md
+++ b/install-guidance.md
@@ -303,94 +303,77 @@ Or `git pull` for symlink installs.
 
 ---
 
-## Google Gemini CLI
+## Google Antigravity CLI (`agy`) / Gemini
 
-kicad-happy is a monorepo with 12 skills under `skills/<name>/SKILL.md`. `gemini skills install <url>` does not recurse, so it fails at the repo root with "No valid skills found". Use one of the approaches below.
+`kicad-happy` is configured as a first-class **Antigravity CLI plugin** with a root `plugin.json` manifest that bundles all 11 skills (`kicad`, `spice`, `emc`, `datasheets`, `bom`, `digikey`, `mouser`, `lcsc`, `element14`, `jlcpcb`, `pcbway`).
 
-### Install (recommended: clone + `gemini skills link`)
+### Install (recommended: plugin mode for on-demand toggling)
 
-`gemini skills link` discovers `SKILL.md` or `*/SKILL.md` one level deep, so point it at the cloned `skills/` directory (not the repo root) to pick up all 12 at once:
+Install directly from GitHub:
+
+```bash
+agy plugin install https://github.com/aklofas/kicad-happy.git
+```
+
+Or clone locally and install:
 
 ```bash
 git clone https://github.com/aklofas/kicad-happy.git
-gemini skills link ./kicad-happy/skills
+agy plugin install kicad-happy
 ```
 
-Add `--scope workspace` to link into the repo-local `.gemini/skills` instead of the user-scope `~/.gemini/skills`.
-
-### Install (per-skill, from git URL)
-
-Use `--path` to install individual skills directly from the repo URL. Requires Gemini CLI from Jan 13 2026 or later (before that, `--path` was rejected with `Unknown arguments: path` — see [#16482](https://github.com/google-gemini/gemini-cli/issues/16482), fixed by [#16537](https://github.com/google-gemini/gemini-cli/pull/16537)).
+You can validate the plugin structure anytime:
 
 ```bash
-# Install all 12 skills:
-for skill in kicad spice emc datasheets bom digikey mouser lcsc element14 jlcpcb pcbway; do
-  gemini skills install https://github.com/aklofas/kicad-happy.git --path skills/$skill
-done
+agy plugin validate kicad-happy
 ```
 
-For repo-local (workspace scope):
+### On-Demand Toggling & Management
 
-```bash
-gemini skills install https://github.com/aklofas/kicad-happy.git --path skills/kicad --scope workspace
-```
+Manage the plugin via CLI commands, interactive chat slash commands, or the Antigravity desktop UI:
 
-### Install (manual symlinks)
+*   **List plugins**: `agy plugin list` / `/plugin list`
+*   **Disable plugin**: `agy plugin disable kicad-happy` / `/plugin disable kicad-happy`
+*   **Enable plugin**: `agy plugin enable kicad-happy` / `/plugin enable kicad-happy`
+*   **Uninstall plugin**: `agy plugin uninstall kicad-happy`
+*   **Desktop UI**: In Antigravity 2.0 / IDE, navigate to **Settings > Skills & Customizations > Plugins** to toggle **kicad-happy** on or off.
 
-If `gemini skills link` is unavailable, symlink directly:
+### Legacy Gemini CLI Migration (`gemini skills link`)
 
-```bash
-git clone https://github.com/aklofas/kicad-happy.git
-cd kicad-happy
-mkdir -p ~/.gemini/skills
-for skill in kicad spice emc datasheets bom digikey mouser lcsc element14 jlcpcb pcbway; do
-  ln -sf "$(pwd)/skills/$skill" ~/.gemini/skills/$skill
-done
-```
+If you previously installed `kicad-happy` using the deprecated `gemini skills link` command:
 
-### Management & Interactive Mode
-
-You can manage skills from the terminal or interactively using slash commands:
-
-*   **`gemini skills list`** / **`/skills list`**: List all discovered skills.
-*   **`gemini skills enable/disable <name>`** / **`/skills enable/disable <name>`**: Toggle a skill.
-*   **`/skills reload`**: Refresh the skill registry (use after editing `SKILL.md` or scripts).
-*   **`/skills link <path>`**: Link local skills during an active session.
+1. Unlink legacy skills from `~/.gemini/skills`:
+   ```bash
+   for skill in kicad spice emc datasheets bom digikey mouser lcsc element14 jlcpcb pcbway; do
+     unlink ~/.gemini/skills/$skill
+   done
+   ```
+2. Reinstall using `agy plugin install`:
+   ```bash
+   agy plugin install kicad-happy
+   ```
 
 ### Skill Tier Precedence
 
-Gemini CLI discovers skills in three tiers with the following precedence:
-1.  **Workspace Tier**: `.gemini/skills/` or `.agents/skills/` in the project root.
-2.  **User Tier**: `~/.gemini/skills/` or `~/.agents/skills/`.
-3.  **Extension Tier**: Bundled within installed extensions.
+Antigravity CLI discovers skills and plugins across three tiers with the following precedence:
+1.  **Workspace Tier**: `.gemini/plugins/` or `.agents/plugins/` in the project root.
+2.  **User Tier**: `~/.gemini/antigravity-cli/plugins/` or `~/.agents/plugins/`.
+3.  **Extension / Built-in Tier**: Bundled system plugins.
 
 ### Upgrade
 
-For `gemini skills link` installs, `git pull` in the cloned repo and run `/skills reload` — symlinks follow the live checkout.
-
-For `--path` installs, reinstall each skill:
+To update `kicad-happy`, run `git pull` in your local checkout and reinstall:
 
 ```bash
-for skill in kicad spice emc datasheets bom digikey mouser lcsc element14 jlcpcb pcbway; do
-  gemini skills uninstall $skill
-  gemini skills install https://github.com/aklofas/kicad-happy.git --path skills/$skill
-done
+cd kicad-happy
+git pull
+agy plugin install .
 ```
-
-### Known issues
-
-- Skill discovery is most stable in v0.25.0+. Ensure your CLI is up to date by running:
-  `npm install -g @google/gemini-cli@latest`
-- The `--path` flag was broken before Jan 13 2026
-  ([#16482](https://github.com/google-gemini/gemini-cli/issues/16482), fixed by
-  [#16537](https://github.com/google-gemini/gemini-cli/pull/16537)). Older CLI
-  versions reject it with `Unknown arguments: path` — upgrade, or fall back to
-  `gemini skills link` / manual symlinks.
-- Large skill directories may take a moment to index during initial startup.
 
 ### Gemini-specific notes
 
 <!-- Gemini maintainers: add platform-specific guidance below this line -->
+
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@ A suite of 11 skills that turn an AI coding agent into an electronics design ass
 
 Capabilities: schematic analysis (40+ subcircuit detectors), PCB layout review, EMC pre-compliance (44 rules), SPICE simulation, thermal analysis, component sourcing (DigiKey/Mouser/LCSC/element14), BOM management, manufacturing prep (JLCPCB/PCBWay), and professional documentation generation.
 
-Install: `/plugin marketplace add aklofas/kicad-happy` (Claude Code), `gemini skills link ./kicad-happy/skills` after cloning (Gemini), or clone and symlink skills.
+Install: `/plugin marketplace add aklofas/kicad-happy` (Claude Code), `agy plugin install kicad-happy` after cloning (Antigravity / Gemini), or clone and symlink skills.
 
 ## Documentation
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > AI-powered design review skills for KiCad electronics projects
 
-A suite of 11 skills that turn an AI coding agent into an electronics design assistant. Structured Python analysis scripts (zero dependencies, Python 3.10+ stdlib only) for KiCad 5-10 projects. Works with Claude Code, OpenAI Codex, Cursor, and Gemini CLI.
+A suite of 11 skills that turn an AI coding agent into an electronics design assistant. Structured Python analysis scripts (zero dependencies, Python 3.10+ stdlib only) for KiCad 5-10 projects. Works with Claude Code, OpenAI Codex, Cursor, and Google Antigravity.
 
 Capabilities: schematic analysis (40+ subcircuit detectors), PCB layout review, EMC pre-compliance (44 rules), SPICE simulation, thermal analysis, component sourcing (DigiKey/Mouser/LCSC/element14), BOM management, manufacturing prep (JLCPCB/PCBWay), and professional documentation generation.
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://antigravity.google/schemas/v1/plugin.json",
+  "name": "kicad-happy",
+  "version": "2.1.0",
+  "description": "KiCad electronics design review. Parse schematics and PCB layouts, run EMC pre-compliance and SPICE simulation, extract structured specs from datasheet PDFs, source components from major distributors, and prep boards for fabrication. Catches real design bugs before you order.",
+  "author": {
+    "name": "aklofas",
+    "url": "https://github.com/aklofas"
+  },
+  "repository": "https://github.com/aklofas/kicad-happy",
+  "license": "MIT",
+  "keywords": [
+    "electronics",
+    "eda",
+    "kicad",
+    "kicad-schematics",
+    "pcb-design",
+    "kicad-pcb",
+    "hardware-design",
+    "design-review",
+    "schematic-analysis"
+  ]
+}


### PR DESCRIPTION
This adds a `plugin.json` to configure this repo as an Antigravity plugin, and updates the documentation to support this.

[The Gemini CLI is deprecated](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/), and Antigravity is the recommended replacement.

I tested that this validates and installs successfully with Antigravity `1.1.11`.