### PR TITLE
fix(kicad): no-connect markers must not create connectivity

### DIFF
--- a/skills/kicad/scripts/analyze_schematic.py
+++ b/skills/kicad/scripts/analyze_schematic.py
@@ -1583,8 +1583,14 @@ def build_net_map(components: list[dict], wires: list[dict], labels: list[dict],
     if no_connects:
         for nc in no_connects:
             sheet = nc.get("_sheet", 0)
-            k = add_point(nc["x"], nc["y"], {"source": "no_connect"}, sheet)
-            union_with_overlapping_wires(k, nc["x"], nc["y"], sheet)
+            # A no-connect marker is an ERC annotation, never a connection.
+            # add_point() already shares the coordinate key with a pin or wire
+            # endpoint on the same point, which is all the absorption and NC
+            # tagging described above needs. Unioning the marker with every
+            # *overlapping* wire also caught wires passing mid-span beneath it,
+            # which KiCad does not connect, dragging the NC'd pin into that
+            # wire's net — a false-positive connection.
+            add_point(nc["x"], nc["y"], {"source": "no_connect"}, sheet)
 
     # Bus pass unions (GH #25). A bus member is joined into the coordinate
     # union-find through a synthetic slot key ("bus", sheet, cluster, member).


### PR DESCRIPTION
## Summary

A `no_connect` marker can create connectivity that KiCad does not have. When the marker sits on a pin and a wire happens to pass **mid-span** beneath that point, the NC'd pin is absorbed into that wire's net.

It is a false-positive connection, which is the dangerous direction — it can hide a genuinely floating pin.

## Symptom

Real case. An RCA jack whose SHUNT pin is intentionally NC'd, with a GND wire running horizontally through that coordinate:

```
J2.3 (SHUNT)  at (55.88, 171.45)                    <- NC marker here
GND wire      (22.86, 171.45) -> (105.41, 171.45)   <- passes through, no junction
```

| | J2.3 | net count |
|---|---|---|
| `kicad-cli sch export netlist` | own net, `unconnected-(J2-SHUNT-Pad3)` | 18 |
| `analyze_schematic.py` @ 43dad23 | folded into `GND` (23 pins) | 17 |

## Root cause

`build_net_map()` registers the marker at the pin's coordinate — correct, that is what tags the net `no_connect` — and then also unions it with overlapping wires:

```python
k = add_point(nc["x"], nc["y"], {"source": "no_connect"}, sheet)
union_with_overlapping_wires(k, nc["x"], nc["y"], sheet)
```

`union_with_overlapping_wires()` unions the point with every wire it *lies on*, mid-span included. That is correct for junctions and labels, and the KH-360 comment documents why. It is not correct for a no-connect marker, which is an ERC annotation and never connects anything. Because the marker shares the pin's coordinate key, the union drags the pin along with it.

## Fix

Drop the union call. `add_point()` already shares the coordinate key with any pin or wire endpoint on that point, so everything the surrounding block exists for keeps working.

## What this does not break

Checks written specifically to catch over-correction, passing before **and** after:

- an NC'd pin on a real wire **endpoint** stays connected to that wire's net
- that net is still tagged `no_connect: true`
- an NC on an isolated pin with no wire still tags the net (no `__unnamed_N` phantom)
- a plain pin mid-span is still not connected (unchanged)

## Verification

**Against `kicad-cli` ground truth** on a 22-component board:

| | nets | agreement with kicad-cli |
|---|---|---|
| `kicad-cli sch export netlist` | 18 | — |
| main | 17 | 16/18 |
| this branch | 18 | **18/18** |

The only net that changes is the one holding the NC'd pin.

**Harness, `smoke` cross-section** (27 repos, 169 projects, 402 files) — run twice, once with `main` and once with this branch, same corpus, same machine:

```
run_schematic.py   402/402 OK both runs, no crashes
run_checks.py      13,025 assertions

               main      this branch
passed        12,531        12,531
failed           410           410
errors            84            84

new failures: 0    newly passing: 0    changed values: 0
```

Comparing assertion-by-assertion by ID, nothing moved. Two caveats I would rather state than paper over:

1. Those 410 failures and 84 errors are **pre-existing on unpatched `main`** in my environment, not caused by this change — identical in both runs. I could not reproduce the 100% in `status.md`, possibly a corpus-state difference on my side, so I am not claiming a 100% pass rate.
2. **`smoke` does not actually exercise this change.** I scanned it for the pattern and found none, so "no regressions" there only demonstrates absence of collateral damage.

**Pattern frequency**, scanned directly over the schematics on disk (35 repos, everything I had cloned):

```
702 .kicad_sch scanned
180 files contain no-connect markers
2,058 no-connect markers total
0 sitting mid-span on a wire
```

So the pattern is rare, which is consistent with nothing moving in the assertions — and suggests re-seeding may not be needed at all. But 35 repos is not 5,829, and I would not want that read as corpus-wide proof.

## Where I got stuck, and what would help

I wanted to give you a full-corpus result and could not, for a boring reason: disk. Measured across the 47 repos I cloned, the corpus averages **189 MB/repo** (median 44 MB, fat tail — `hackclub/OnBoard` alone is 2.6 GB). Extrapolated to 5,820 repos that is **255 GB by median, ~1.1 TB by mean**, which does not fit on the machine I have.

Two ways I can see around it, happy to do either:

- **Batch it** — clone ~300 repos, run both analyzers, diff, delete, repeat. Bounds peak disk to ~50 GB, still pulls the full corpus over the wire.
- **Sparse clones** — `analyze_schematic.py` only reads `.kicad_sch`, and that is a tiny fraction of these repos (the bulk is 3D models, gerbers, images). A `--filter=blob:none` clone with sparse-checkout limited to schematics should cut the download by an order of magnitude and make a genuine corpus-wide scan practical.

**So: what would you like me to run?** If you tell me which cross-sections or repo list you consider sufficient, I will run exactly that and post the numbers. If you would rather run it yourself on the real harness box, that is probably faster than anything I can do — and if you would prefer a different fix (for example keeping the union but excluding mid-span hits for NC markers only), say so and I will rework it.

## Repro, no corpus needed

```python
import importlib.util, os, sys
p = sys.argv[1]  # path to analyze_schematic.py
sys.path.insert(0, os.path.dirname(p))
spec = importlib.util.spec_from_file_location("az", p)
m = importlib.util.module_from_spec(spec); sys.modules["az"] = m; spec.loader.exec_module(m)

def comp(ref, x, y):
    return {"reference": ref, "value": "X", "type": "symbol", "x": x, "y": y, "_sheet": 0,
            "pins": [{"number": "1", "name": "P", "type": "passive", "x": x, "y": y}]}

nets = m.build_net_map([comp("U1", 5.0, 0.0), comp("U2", 0.0, 0.0)],
                       [{"x1": 0, "y1": 0, "x2": 10, "y2": 0, "_sheet": 0}],
                       [], [], [], [{"x": 5.0, "y": 0.0, "_sheet": 0}])
for name, n in nets.items():
    print(name, sorted(f"{q['component']}.{q['pin_number']}" for q in n["pins"]))

# main:        one net  -> ['U1.1', 'U2.1']    (wrong)
# this branch: two nets -> ['U1.1'], ['U2.1']  (matches kicad-cli)
```
